### PR TITLE
Fix server crash

### DIFF
--- a/scripting/nt_doublecap.sp
+++ b/scripting/nt_doublecap.sp
@@ -9,7 +9,7 @@ public Plugin:myinfo =
     name = "NEOTOKYO° Double cap prevention",
     author = "soft as HELL",
     description = "Removes ghost as soon as it's captured",
-    version = "0.3.1",
+    version = "0.4.0",
     url = ""
 };
 
@@ -31,6 +31,11 @@ public OnGhostCapture(client)
 
 RemoveGhost(client)
 {
+	if(!IsValidEdict(ghost))
+	{
+		return;
+	}
+
 	PrintToServer("Removing current ghost %i", ghost);
 
 	// Switch to last weapon if player is still alive and has ghost active
@@ -44,13 +49,20 @@ RemoveGhost(client)
 			new lastweapon = GetEntPropEnt(client, Prop_Data, "m_hLastWeapon");
 
 			if(IsValidEdict(lastweapon))
-				SetEntPropEnt(client, Prop_Data, "m_hActiveWeapon", lastweapon);
+			{
+				int owner = GetEntPropEnt(lastweapon, Prop_Data, "m_hOwnerEntity");
+				// If the player dropped all of their weapons except the ghost,
+				// their m_hLastWeapon will point to a gun that's not on them,
+				// and trying to set it as m_hActiveWeapon will crash the server.
+				// This can happen for knifeless players, ie. supports.
+				if (client == owner)
+				{
+					SetEntPropEnt(client, Prop_Data, "m_hActiveWeapon", lastweapon);
+				}
+			}
 		}
 	}
 
 	// Delete ghost
-	if(IsValidEdict(ghost))
-	{
-		AcceptEntityInput(ghost, "Kill");
-	}
+	AcceptEntityInput(ghost, "Kill");
 }


### PR DESCRIPTION
This fixes an issue where a player who dropped all of their weapons except the ghost will crash the server when RemoveGhost() gets called on them. The bug happens because the m_hLastWeapon property of such a player will point to a weapon that they don't hold, so the subsequent attempt to set their m_hActiveWeapon to it will trigger a crash. This can happen if a knifeless player (ie. a support) has dropped all of their guns, and used all of their nades, and then caps the ghost.

Bug report and reproducible case provided by bauxite (thanks!)