### PR TITLE
Fix server crash on late load

### DIFF
--- a/scripting/nt_doublecap.sp
+++ b/scripting/nt_doublecap.sp
@@ -9,11 +9,11 @@ public Plugin:myinfo =
     name = "NEOTOKYO° Double cap prevention",
     author = "soft as HELL",
     description = "Removes ghost as soon as it's captured",
-    version = "0.4.0",
+    version = "0.5.0",
     url = ""
 };
 
-new ghost;
+new ghost = INVALID_ENT_REFERENCE;
 
 public OnGhostSpawn(entity)
 {


### PR DESCRIPTION
The ghost entref variable is default-initialized to 0, and later in RemoveGhost, its validity is checked with IsValidEdict. But 0 passes IsValidEdict, because it is the server's edict. If the plugin loads late and misses the OnGhostSpawn event which sets the ghost reference to something nonzero, a RemoveGhost call will send the "Kill" input to entity 0 (the server itself), which causes a crash.