### PR TITLE
Fix database bugs

### DIFF
--- a/scripting/nt_savescores.sp
+++ b/scripting/nt_savescores.sp
@@ -9,7 +9,7 @@ public Plugin myinfo =
     name = "NEOTOKYO° Temporary score saver",
     author = "soft as HELL",
     description = "Saves score when player disconnects and restores it if player connects back before map change",
-    version = "0.5.1",
+    version = "0.5.2",
     url = "https://github.com/softashell/nt-sourcemod-plugins"
 };
 
@@ -210,6 +210,9 @@ public void DB_retrieveScoreCallback(Handle owner, Handle hndl, const char[] err
 		return;
 
 	if (SQL_GetRowCount(hndl) == 0)
+		return;
+
+	if (!SQL_FetchRow(hndl))
 		return;
 
 	int xp = SQL_FetchInt(hndl, 1);

--- a/scripting/nt_savescores.sp
+++ b/scripting/nt_savescores.sp
@@ -165,7 +165,11 @@ void DB_insertScore(int client)
 
 	Format(query, sizeof(query), "INSERT OR REPLACE INTO nt_saved_score VALUES ('%s', %d, %d);", steamID, xp, deaths);
 
+	SQL_LockDatabase(hDB);
+
 	SQL_FastQuery(hDB, query);
+
+	SQL_UnlockDatabase(hDB);
 }
 
 void DB_deleteScore(int client)
@@ -179,7 +183,11 @@ void DB_deleteScore(int client)
 
 	Format(query, sizeof(query), "DELETE FROM nt_saved_score WHERE steamID = '%s';", steamID);
 
+	SQL_LockDatabase(hDB);
+
 	SQL_FastQuery(hDB, query);
+
+	SQL_UnlockDatabase(hDB);
 }
 
 void DB_retrieveScore(int client)

--- a/scripting/nt_savescores.sp
+++ b/scripting/nt_savescores.sp
@@ -203,19 +203,20 @@ void DB_retrieveScore(int client)
 
 	Format(query, sizeof(query), "SELECT * FROM	nt_saved_score WHERE steamID = '%s';", steamID);
 
-	SQL_TQuery(hDB, DB_retrieveScoreCallback, query, client);
+	SQL_TQuery(hDB, DB_retrieveScoreCallback, query, GetClientUserId(client));
 }
 
-public void DB_retrieveScoreCallback(Handle owner, Handle hndl, const char[] error, int client)
+public void DB_retrieveScoreCallback(Handle owner, Handle hndl, const char[] error, int userid)
 {
+	int client = GetClientOfUserId(userid);
+	if (client == 0)
+		return;
+
 	if (hndl == INVALID_HANDLE)
 	{
 		LogError("SQL Error: %s", error);
 		return;
 	}
-
-	if(!IsValidClient(client))
-		return;
 
 	if (SQL_GetRowCount(hndl) == 0)
 		return;

--- a/scripting/nt_savescores.sp
+++ b/scripting/nt_savescores.sp
@@ -9,7 +9,7 @@ public Plugin myinfo =
     name = "NEOTOKYO° Temporary score saver",
     author = "soft as HELL",
     description = "Saves score when player disconnects and restores it if player connects back before map change",
-    version = "0.5.2",
+    version = "0.5.3",
     url = "https://github.com/softashell/nt-sourcemod-plugins"
 };
 


### PR DESCRIPTION
64a7ba4da9e5c15a7949833984ac4887895d4388 fixes the nt_savescores plugin crashing for SourceMod versions newer than 1.10, with error:
> L 08/22/2023 - 21:33:52: [SM] Exception reported: Current result set has no fetched rows
> L 08/22/2023 - 21:33:52: [SM] Blaming: nt\nt_savescores.smx
> L 08/22/2023 - 21:33:52: [SM] Call stack trace:
> L 08/22/2023 - 21:33:52: [SM]   [0] SQL_FetchInt
> L 08/22/2023 - 21:33:52: [SM]   [1] Line 208, nt_savescores.sp::DB_retrieveScoreCallback

Thanks to bauxite for reporting this.

Also including some other minor fixes while at it.