### PR TITLE
nt_damage bug fix

### DIFF
--- a/scripting/nt_damage.sp
+++ b/scripting/nt_damage.sp
@@ -12,7 +12,7 @@ public Plugin myinfo =
     name = "NEOTOKYO° Damage counter",
     author = "soft as HELL",
     description = "Shows detailed damage list on death/round end",
-    version = "0.7.5",
+    version = "0.7.6",
     url = ""
 };
 
@@ -50,13 +50,6 @@ public void OnPluginStart()
 	HookEvent("player_death", OnPlayerDeath, EventHookMode_Post);
 }
 
-public void OnClientPutInServer(int client)
-{
-	g_SeenReport[client] = false;
-	g_PlayerAssist[client] = 0;
-	g_PlayerClass[client] = CLASS_NONE;
-}
-
 public void OnRoundStart(Handle event, const char[] name, bool dontBroadcast)
 {
 	int client, victim;
@@ -69,7 +62,10 @@ public void OnRoundStart(Handle event, const char[] name, bool dontBroadcast)
 			if(!g_SeenReport[client])
 				DamageReport(client);
 		}
+	}
 
+	for(client = 1; client <= MaxClients; client++)
+	{
 		// Resets everything
 		g_SeenReport[client] = false;
 		g_PlayerHealth[client] = 100;


### PR DESCRIPTION
Bug where class wouldn't display properly and instead show [-] when there was no apparent reason for it.

Realized we need to show all the damage reports first, before we start resetting the variables.

Removed resetting the variables when client is put into server, as clients often rejoin during rounds, doesn't seem like it's needed as when the players spawn in everything should be correct.